### PR TITLE
now <SPACE>bb list the buffers and wait for the ID to change into it.

### DIFF
--- a/plugin/spacemacs.vim
+++ b/plugin/spacemacs.vim
@@ -5,7 +5,7 @@
 let s:nativeKeyBindings = {
   \ 'nnoremap': {
     \ '<TAB>': '<C-^>',
-    \ 'bb': ':buffers<CR>',
+    \ 'bb': ':buffers<CR>:buffer<Space>',
     \ 'bd': ':bdelete<CR>',
     \ 'bn': ':bn<CR>',
     \ 'bp': ':bp<CR>',


### PR DESCRIPTION
The current behavior of <SPACE>bb in Spacemacs (on Emacs) is to list the buffers in a minibuffer, letting the user to choose a buffer to switch to. This may be mimic in VIM easily if we run :buffers followed by a :buffer

I made the change myself. Please test it and let me know if you find troubles.
